### PR TITLE
added support for taxonomy default in contenttypes.yml

### DIFF
--- a/src/Content.php
+++ b/src/Content.php
@@ -56,6 +56,12 @@ class Content implements \ArrayAccess
 
                     // add support for taxonomy default value when options is set
                     $defaultValue = $this->app['config']->get('taxonomy/' . $taxonomytype . '/default');
+                    
+                    // add support for taxonomy default per contenttype
+                     if (isset($this->contenttype['default'.$taxonomytype])){
+                        $defaultValue = $this->contenttype['default'.$taxonomytype];
+                    }
+
                     $options = $this->app['config']->get('taxonomy/' . $taxonomytype . '/options');
                     if (isset($options) &&
                             isset($defaultValue) &&


### PR DESCRIPTION
with this line in the content constructor we have the option to add a default to the contenttypes.yml.
usage: 
   taxonomy: [mycategories]
   default_mycategories: "category2"